### PR TITLE
feat: add JPA entities for users and authentication tokens

### DIFF
--- a/apps/backend/src/main/java/com/resumeagent/entity/EmailVerificationTokens.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/EmailVerificationTokens.java
@@ -1,0 +1,97 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "email_verification_tokens",
+        indexes = {
+                @Index(name = "idx_email_verification_user_id", columnList = "user_id"),
+                @Index(name = "idx_email_verification_token", columnList = "token"),
+                @Index(name = "idx_email_verification_expires", columnList = "expires_at")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "token")
+public class EmailVerificationTokens implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // -------------------------------------------------------------------------
+    // Token Data
+    // -------------------------------------------------------------------------
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private boolean used = false;
+
+    @Column(name = "used_at")
+    private Instant usedAt;
+
+    // -------------------------------------------------------------------------
+    // Auditing
+    // -------------------------------------------------------------------------
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle Callbacks
+    // -------------------------------------------------------------------------
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+
+    // -------------------------------------------------------------------------
+    // Domain Logic (Optional but Recommended)
+    // -------------------------------------------------------------------------
+
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+
+    public boolean isUsable() {
+        return !used && !isExpired();
+    }
+
+    public void markUsed() {
+        this.used = true;
+        this.usedAt = Instant.now();
+    }
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/PasswordHistory.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/PasswordHistory.java
@@ -1,0 +1,66 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "password_history",
+        indexes = {
+                @Index(name = "idx_password_history_user_id", columnList = "user_id"),
+                @Index(name = "idx_password_history_created_at", columnList = "created_at DESC")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "passwordHash")
+public class PasswordHistory implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // -------------------------------------------------------------------------
+    // Password Data
+    // -------------------------------------------------------------------------
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    // -------------------------------------------------------------------------
+    // Auditing
+    // -------------------------------------------------------------------------
+
+    @Column(
+            name = "created_at",
+            nullable = false,
+            updatable = false,
+            insertable = false
+    )
+    private Instant createdAt;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/PasswordResetTokens.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/PasswordResetTokens.java
@@ -1,0 +1,103 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "password_reset_tokens",
+        indexes = {
+                @Index(name = "idx_password_reset_user_id", columnList = "user_id"),
+                @Index(name = "idx_password_reset_token", columnList = "token"),
+                @Index(name = "idx_password_reset_expires", columnList = "expires_at")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = { "token", "userAgent", "ipAddress" })
+public class PasswordResetTokens implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // -------------------------------------------------------------------------
+    // Token Data
+    // -------------------------------------------------------------------------
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private boolean used = false;
+
+    @Column(name = "used_at")
+    private Instant usedAt;
+
+    // -------------------------------------------------------------------------
+    // Audit / Tracking
+    // -------------------------------------------------------------------------
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "user_agent", columnDefinition = "TEXT")
+    private String userAgent;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle Callbacks
+    // -------------------------------------------------------------------------
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+
+    // -------------------------------------------------------------------------
+    // Domain Logic
+    // -------------------------------------------------------------------------
+
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+
+    public boolean isUsable() {
+        return !used && !isExpired();
+    }
+
+    public void markUsed() {
+        this.used = true;
+        this.usedAt = Instant.now();
+    }
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/User.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/User.java
@@ -1,0 +1,110 @@
+package com.resumeagent.entity;
+
+import com.resumeagent.entity.enums.UserPlan;
+import com.resumeagent.entity.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_users_email", columnList = "email"),
+                @Index(name = "idx_users_role", columnList = "user_role"),
+                @Index(name = "idx_users_created_at", columnList = "created_at")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "passwordHash")
+public class User implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Identity & Authentication
+    // -------------------------------------------------------------------------
+
+    @Column(name = "full_name", nullable = false, length = 150)
+    private String fullName;
+
+    @Column(name = "email", nullable = false, unique = true, length = 150)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    // -------------------------------------------------------------------------
+    // Authorization & Subscription
+    // -------------------------------------------------------------------------
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false, length = 10)
+    private UserRole userRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plan", nullable = false, length = 20)
+    private UserPlan plan = UserPlan.FREE;
+
+    // -------------------------------------------------------------------------
+    // Usage Limits
+    // -------------------------------------------------------------------------
+
+    @Column(name = "resume_generation_limit", nullable = false)
+    private int resumeGenerationLimit = 5;
+
+    @Column(name = "resume_generation_used", nullable = false)
+    private int resumeGenerationUsed = 0;
+
+    // -------------------------------------------------------------------------
+    // Status Flags
+    // -------------------------------------------------------------------------
+
+    @Column(name = "is_email_active", nullable = false)
+    private boolean emailActive = false;
+
+    // -------------------------------------------------------------------------
+    // Auditing
+    // -------------------------------------------------------------------------
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle Callbacks
+    // -------------------------------------------------------------------------
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/enums/UserPlan.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/enums/UserPlan.java
@@ -1,0 +1,6 @@
+package com.resumeagent.entity.enums;
+
+public enum UserPlan {
+    FREE,
+    PRO
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/enums/UserRole.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.resumeagent.entity.enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}


### PR DESCRIPTION
Adds JPA entity classes for core user accounts and authentication-related security tokens as defined
in the Flyway V1 schema.

Includes user role and plan enums, password history, and email/password token entities to establish the foundation for authentication and account management.