### PR TITLE
Add resume and agent log entities and align schema enum constraints

### DIFF
--- a/apps/backend/src/main/java/com/resumeagent/entity/Resume.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/Resume.java
@@ -1,0 +1,91 @@
+package com.resumeagent.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resumes",
+        indexes = {
+                @Index(name = "idx_resumes_user_id", columnList = "user_id"),
+                @Index(name = "idx_resumes_created_at", columnList = "created_at"),
+                @Index(name = "idx_resumes_job_title", columnList = "job_title_targeted")
+        }
+)
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EqualsAndHashCode(of = "id")
+public class Resume implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id",  nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // -------------------------------------------------------------------------
+    // Targeted Job Role (Title) & Company Name
+    // -------------------------------------------------------------------------
+
+    @Column(name = "job_title_targeted",  nullable = false)
+    private String jobTitleTargeted;
+
+    @Column(name = "company_targeted", nullable = false)
+    private String companyTargeted;
+
+    // -------------------------------------------------------------------------
+    // Resumes Versions
+    // -------------------------------------------------------------------------
+
+    @Column(name = "current_version", nullable = false)
+    private int currentVersion = 1;
+
+    // -------------------------------------------------------------------------
+    // Auditing
+    // -------------------------------------------------------------------------
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle Callbacks
+    // -------------------------------------------------------------------------
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeAgentLog.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeAgentLog.java
@@ -1,0 +1,113 @@
+package com.resumeagent.entity;
+
+import com.resumeagent.entity.enums.AgentExecutionStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Audit trail for AI agent operations with performance metrics.
+ * Maps to table: resume_agent_logs
+ */
+@Entity
+@Table(
+        name = "resume_agent_logs",
+        indexes = {
+                @Index(name = "idx_agent_logs_user_id", columnList = "user_id"),
+                @Index(name = "idx_agent_logs_resume_id", columnList = "resume_id"),
+                @Index(name = "idx_agent_logs_agent_name", columnList = "agent_name"),
+                @Index(name = "idx_agent_logs_created_at", columnList = "created_at")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "errorMessage")
+public class ResumeAgentLog implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+    /**
+     * The user who triggered this agent run. DB: NOT NULL, FK -> users(id) ON DELETE CASCADE.
+     * Keep FetchType.LAZY to avoid unnecessary joins when not required.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_agent_logs_user"))
+    private User user;
+
+    /**
+     * Optional reference to a resume; nullable, DB-level FK ON DELETE SET NULL.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id",
+            foreignKey = @ForeignKey(name = "fk_agent_logs_resume"))
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Attributes
+    // -------------------------------------------------------------------------
+    @Column(name = "agent_name", nullable = false, length = 100)
+    private String agentName;
+
+    @Column(name = "tokens_input")
+    private Integer tokensInput;
+
+    @Column(name = "tokens_output")
+    private Integer tokensOutput;
+
+    /**
+     * Execution time in milliseconds.
+     */
+    @Column(name = "execution_time_ms")
+    private Integer executionTimeMs;
+
+    /**
+     * Execution status stored as String (EnumType.STRING).
+     * DB CHECK expects uppercase values: 'SUCCESS','FAILURE','PARTIAL'
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private AgentExecutionStatus status = AgentExecutionStatus.PARTIAL;
+
+    @Column(name = "error_message", columnDefinition = "text")
+    private String errorMessage;
+
+    // -------------------------------------------------------------------------
+    // Auditing
+    // -------------------------------------------------------------------------
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle callbacks
+    // -------------------------------------------------------------------------
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+        if (this.status == null) {
+            this.status = AgentExecutionStatus.PARTIAL;
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/enums/AgentExecutionStatus.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/enums/AgentExecutionStatus.java
@@ -1,0 +1,14 @@
+package com.resumeagent.entity.enums;
+
+/**
+ * Execution status for agent runs.
+
+ * Note: Values are stored in the DB as uppercase strings using EnumType.STRING.
+ * The DB CHECK constraint must match these values:
+ *   CHECK (status IN ('SUCCESS', 'FAILURE', 'PARTIAL'))
+ */
+public enum AgentExecutionStatus {
+    SUCCESS,
+    FAILURE,
+    PARTIAL
+}

--- a/apps/backend/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/apps/backend/src/main/resources/db/migration/V1__initial_schema.sql
@@ -131,7 +131,7 @@ COMMENT ON TABLE resume_summary IS 'Professional summary section of resume';
 CREATE TABLE resume_skills (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     resume_id UUID NOT NULL REFERENCES resumes(id) ON DELETE CASCADE,
-    category VARCHAR(50) NOT NULL CHECK (category IN ('languages', 'frameworks', 'tools', 'concepts', 'other')),
+    category VARCHAR(50) NOT NULL CHECK (category IN ('LANGUAGES', 'FRAMEWORKS', 'TOOLS', 'CONCEPTS', 'OTHERS')),
     skill VARCHAR(100) NOT NULL
 );
 
@@ -153,7 +153,7 @@ CREATE TABLE resume_experience (
     role VARCHAR(150) NOT NULL,
     company VARCHAR(150) NOT NULL,
     location VARCHAR(150),
-    employment_type VARCHAR(50) CHECK (employment_type IN ('Full-time', 'Part-time', 'Contract', 'Intern', 'Freelance')),
+    employment_type VARCHAR(50) CHECK (employment_type IN ('FULL-TIME', 'PART-TIME', 'CONTRACT', 'INTERN', 'FREELANCE')),
     start_date DATE NOT NULL,
     end_date DATE,
     technologies TEXT[],
@@ -175,7 +175,7 @@ COMMENT ON COLUMN resume_experience.technologies IS 'Array of technologies used 
 CREATE TABLE resume_experience_bullets (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     experience_id UUID NOT NULL REFERENCES resume_experience(id) ON DELETE CASCADE,
-    bullet_type VARCHAR(50) NOT NULL CHECK (bullet_type IN ('responsibility', 'achievement')),
+    bullet_type VARCHAR(50) NOT NULL CHECK (bullet_type IN ('RESPONSIBILITY' , 'ACHIEVEMENT')),
     content TEXT NOT NULL
 );
 
@@ -337,7 +337,7 @@ CREATE TABLE resume_agent_logs (
     tokens_input INT,
     tokens_output INT,
     execution_time_ms INT,
-    status VARCHAR(20) CHECK (status IN ('success', 'failure', 'partial')),
+    status VARCHAR(20) CHECK (status IN ('SUCCESS', 'FAILURE', 'PARTIAL')),
     error_message TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
Introduces JPA entity mappings for resumes and AI agent
execution logs, and updates the Flyway V1 schema to
standardize enum CHECK constraint values.

This ensures consistency between database constraints
and Java enum definitions.

## Motivation
The resume domain and AI agent audit logging are core
backend concepts and require proper persistence models.

During entity implementation, lowercase CHECK constraint
values were normalized to uppercase to align with Java
enum naming conventions and avoid case-sensitivity bugs
during persistence and querying.

## What’s Included
### Entity Layer
- Resume entity
- ResumeAgentLog entity
- AgentExecutionStatus enum

### Database Schema
- Updated CHECK constraints to use uppercase values
  (e.g. `SUCCESS`, `FAILURE`, `PARTIAL`)
- No structural table changes

## Scope
- No new tables introduced
- No column additions or removals
- Enum value normalization only

## Notes
- This change preserves semantic meaning while improving
  consistency between application and database layers.
- Existing data (if any) may require normalization before
  applying the migration in non-greenfield environments.

## Follow-ups
- Add remaining resume section entities
- Introduce repositories for resume and agent log entities
- Add service layer for agent execution tracking
