### PR TITLE
Add JPA entities for structured resume content sections

### DIFF
--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeAchievement.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeAchievement.java
@@ -1,0 +1,40 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_achievements",
+        indexes = {
+                @Index(name = "idx_resume_achievements_resume_id", columnList = "resume_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeAchievement implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeAdditionalSection.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeAdditionalSection.java
@@ -1,0 +1,44 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_additional_sections",
+        indexes = {
+                @Index(name = "idx_resume_additional_sections_resume_id", columnList = "resume_id"),
+                @Index(name = "idx_resume_additional_sections_name", columnList = "section_name")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeAdditionalSection implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Column(name = "section_name", nullable = false, length = 100)
+    private String sectionName;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeCertification.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeCertification.java
@@ -1,0 +1,47 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_certifications",
+        indexes = {
+                @Index(name = "idx_resume_certifications_resume_id", columnList = "resume_id"),
+                @Index(name = "idx_resume_certifications_year", columnList = "year DESC")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeCertification implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Column(name = "name", nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "issuer", nullable = false, length = 200)
+    private String issuer;
+
+    @Column(name = "year")
+    private Integer year;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeEducation.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeEducation.java
@@ -1,0 +1,74 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_education",
+        indexes = {
+                @Index(
+                        name = "idx_resume_education_resume_id",
+                        columnList = "resume_id"
+                ),
+                @Index(
+                        name = "idx_resume_education_years",
+                        columnList = "end_year DESC"
+                )
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeEducation implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Education Details
+    // -------------------------------------------------------------------------
+
+    @Column(name = "degree", nullable = false, length = 150)
+    private String degree;
+
+    @Column(name = "field", length = 150)
+    private String field;
+
+    @Column(name = "institution", nullable = false, length = 200)
+    private String institution;
+
+    @Column(name = "location", length = 150)
+    private String location;
+
+    @Column(name = "start_year")
+    private Integer startYear;
+
+    @Column(name = "end_year")
+    private Integer endYear;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeExperience.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeExperience.java
@@ -1,0 +1,94 @@
+package com.resumeagent.entity;
+
+import com.resumeagent.entity.enums.EmploymentType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_experience",
+        indexes = {
+                @Index(name = "idx_resume_experience_resume_id", columnList = "resume_id"),
+                @Index(
+                        name = "idx_resume_experience_dates",
+                        columnList = "start_date DESC, end_date DESC"
+                )
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeExperience implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Role & Company Information
+    // -------------------------------------------------------------------------
+
+    @Column(name = "role", nullable = false, length = 150)
+    private String role;
+
+    @Column(name = "company", nullable = false, length = 150)
+    private String company;
+
+    @Column(name = "location", length = 150)
+    private String location;
+
+    // -------------------------------------------------------------------------
+    // Employment Details
+    // -------------------------------------------------------------------------
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "employment_type", length = 50)
+    private EmploymentType employmentType;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    // -------------------------------------------------------------------------
+    // Technologies Used
+    // -------------------------------------------------------------------------
+
+    /**
+     * PostgreSQL TEXT[] mapping.
+     * Requires Hibernate.
+     */
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "technologies", columnDefinition = "TEXT[]")
+    private String[] technologies;
+
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeExperienceBullet.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeExperienceBullet.java
@@ -1,0 +1,68 @@
+package com.resumeagent.entity;
+
+import com.resumeagent.entity.enums.ExperienceBulletType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_experience_bullets",
+        indexes = {
+                @Index(
+                        name = "idx_experience_bullets_experience_id",
+                        columnList = "experience_id"
+                ),
+                @Index(
+                        name = "idx_experience_bullets_type",
+                        columnList = "bullet_type"
+                )
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "experience")
+public class ResumeExperienceBullet implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private ResumeExperience experience;
+
+    // -------------------------------------------------------------------------
+    // Bullet Classification
+    // -------------------------------------------------------------------------
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "bullet_type", nullable = false, length = 50)
+    private ExperienceBulletType bulletType;
+
+    // -------------------------------------------------------------------------
+    // Bullet Content
+    // -------------------------------------------------------------------------
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeHeader.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeHeader.java
@@ -1,0 +1,87 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_header",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_resume_header",
+                        columnNames = "resume_id"
+                )
+        },
+        indexes = {
+                @Index(name = "idx_resume_header_resume_id", columnList = "resume_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeHeader implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    /**
+     * One-to-one relationship with Resume.
+     * Enforced at DB level via UNIQUE (resume_id).
+     */
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false, unique = true)
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Contact Information
+    // -------------------------------------------------------------------------
+
+    @Column(name = "full_name", nullable = false, length = 150)
+    private String fullName;
+
+    @Column(name = "location", length = 150)
+    private String location;
+
+    @Column(name = "phone", length = 50)
+    private String phone;
+
+    @Column(name = "email", nullable = false, length = 150)
+    private String email;
+
+    // -------------------------------------------------------------------------
+    // Professional Summary & Links
+    // -------------------------------------------------------------------------
+
+    @Column(name = "headline", length = 200)
+    private String headline;
+
+    @Column(name = "linkedin", columnDefinition = "TEXT")
+    private String linkedin;
+
+    @Column(name = "github", columnDefinition = "TEXT")
+    private String github;
+
+    @Column(name = "portfolio", columnDefinition = "TEXT")
+    private String portfolio;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeProject.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeProject.java
@@ -1,0 +1,72 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_projects",
+        indexes = {
+                @Index(name = "idx_resume_projects_resume_id", columnList = "resume_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeProject implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Project Details
+    // -------------------------------------------------------------------------
+
+    @Column(name = "name", nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "type", length = 100)
+    private String type;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    // -------------------------------------------------------------------------
+    // Technologies Used (PostgreSQL TEXT[])
+    // -------------------------------------------------------------------------
+
+    /**
+     * PostgreSQL TEXT[] mapping.
+     * Hibernate-specific.
+     */
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "technologies", columnDefinition = "TEXT[]")
+    private String[] technologies;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeProjectHighlight.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeProjectHighlight.java
@@ -1,0 +1,55 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_project_highlights",
+        indexes = {
+                @Index(
+                        name = "idx_project_highlights_project_id",
+                        columnList = "project_id"
+                )
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "project")
+public class ResumeProjectHighlight implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private ResumeProject project;
+
+    // -------------------------------------------------------------------------
+    // Highlight Content
+    // -------------------------------------------------------------------------
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumePublication.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumePublication.java
@@ -1,0 +1,46 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_publications",
+        indexes = {
+                @Index(name = "idx_resume_publications_resume_id", columnList = "resume_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumePublication implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "platform", length = 100)
+    private String platform;
+
+    @Column(name = "url", columnDefinition = "TEXT")
+    private String url;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeSkill.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeSkill.java
@@ -1,0 +1,59 @@
+package com.resumeagent.entity;
+
+import com.resumeagent.entity.enums.SkillCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_skills",
+        indexes = {
+                @Index(name = "idx_resume_skills_resume_id", columnList = "resume_id"),
+                @Index(name = "idx_resume_skills_category", columnList = "category"),
+                @Index(name = "idx_resume_skills_skill", columnList = "skill")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeSkill implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Skill Classification
+    // -------------------------------------------------------------------------
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    private SkillCategory category;
+
+    @Column(name = "skill", nullable = false, length = 100)
+    private String skill;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/ResumeSummary.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/ResumeSummary.java
@@ -1,0 +1,62 @@
+package com.resumeagent.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "resume_summary",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_resume_summary",
+                        columnNames = "resume_id"
+                )
+        },
+        indexes = {
+                @Index(name = "idx_resume_summary_resume_id", columnList = "resume_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@ToString(exclude = "resume")
+public class ResumeSummary implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    // -------------------------------------------------------------------------
+    // Primary Key
+    // -------------------------------------------------------------------------
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    /**
+     * One-to-one relationship with Resume.
+     * Enforced at DB level via UNIQUE (resume_id).
+     */
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "resume_id", nullable = false, unique = true)
+    private Resume resume;
+
+    // -------------------------------------------------------------------------
+    // Summary Content
+    // -------------------------------------------------------------------------
+
+    @Column(name = "summary_text", nullable = false, columnDefinition = "TEXT")
+    private String summaryText;
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/enums/EmploymentType.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/enums/EmploymentType.java
@@ -1,0 +1,9 @@
+package com.resumeagent.entity.enums;
+
+public enum EmploymentType {
+    FULL_TIME,
+    PART_TIME,
+    CONTRACT,
+    INTERN,
+    FREELANCE
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/enums/ExperienceBulletType.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/enums/ExperienceBulletType.java
@@ -1,0 +1,6 @@
+package com.resumeagent.entity.enums;
+
+public enum ExperienceBulletType {
+    RESPONSIBILITY,
+    ACHIEVEMENT
+}

--- a/apps/backend/src/main/java/com/resumeagent/entity/enums/SkillCategory.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/enums/SkillCategory.java
@@ -1,0 +1,9 @@
+package com.resumeagent.entity.enums;
+
+public enum SkillCategory {
+    LANGUAGES,
+    FRAMEWORKS,
+    TOOLS,
+    CONCEPTS,
+    OTHERS
+}


### PR DESCRIPTION
## Summary
Adds JPA entity classes and supporting enums for all
structured resume content sections defined in the
Flyway V1 database schema.

This completes the persistence layer for resume content
under the Resume aggregate.

## Issue
Closes: Create entity classes for structured resume content sections

## What’s Included
### Resume Content Entities
- Header and summary sections
- Skills with categorized enums
- Experience entries and ordered bullet points
- Projects and project highlights
- Education and certifications
- Achievements and publications
- Flexible additional sections

### Enums
- SkillCategory
- EmploymentType
- ExperienceBulletType

## Acceptance Criteria
- Clear ownership under the Resume aggregate ✅
- Correct cascading and lifecycle rules ✅
- Ordered collections where applicable (e.g. bullets, highlights) ✅

## Scope
- Entity layer only
- No schema or migration changes
- No repositories or services introduced

## Notes
All mappings strictly align with the Flyway V1 schema.
Any future structural changes must be introduced via
new migrations.

## Follow-ups
- Add JPA repositories for resume entities
- Implement resume creation and update workflows
- Add validation and business rules at service layer