### PR TITLE
Add update master resume API

### DIFF
--- a/apps/backend/src/main/java/com/resumeagent/controller/MasterResumeController.java
+++ b/apps/backend/src/main/java/com/resumeagent/controller/MasterResumeController.java
@@ -1,6 +1,6 @@
 package com.resumeagent.controller;
 
-import com.resumeagent.dto.request.CreateMasterResume;
+import com.resumeagent.dto.request.CreateAndUpdateMasterResume;
 import com.resumeagent.dto.response.CommonResponse;
 import com.resumeagent.service.MasterResumeService;
 import jakarta.validation.Valid;
@@ -20,13 +20,23 @@ public class MasterResumeController {
      * Creates a new Master Resume for the authenticated user.
      * Only one master resume per user is allowed in Phase 1.
      */
-    @PostMapping
+    @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
     public CommonResponse createMasterResume(
             Authentication authentication,
-            @Valid @RequestBody CreateMasterResume request
+            @Valid @RequestBody CreateAndUpdateMasterResume request
     ) {
         String email = authentication.getName();
         return masterResumeService.createMasterResume(request, email);
+    }
+
+    @PutMapping(value = "/update")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public CommonResponse updateMasterResume(
+            Authentication authentication,
+            @Valid @RequestBody CreateAndUpdateMasterResume request
+    ) {
+        String email = authentication.getName();
+        return masterResumeService.updateMasterResume(request, email);
     }
 }

--- a/apps/backend/src/main/java/com/resumeagent/dto/request/CreateAndUpdateMasterResume.java
+++ b/apps/backend/src/main/java/com/resumeagent/dto/request/CreateAndUpdateMasterResume.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import java.util.List;
 
 @Data
-public class CreateMasterResume {
+public class CreateAndUpdateMasterResume {
 
     private Metadata metadata;
     private Header header;

--- a/apps/backend/src/main/java/com/resumeagent/entity/MasterResume.java
+++ b/apps/backend/src/main/java/com/resumeagent/entity/MasterResume.java
@@ -1,6 +1,5 @@
 package com.resumeagent.entity;
 
-import com.resumeagent.dto.request.CreateMasterResume;
 import com.resumeagent.entity.model.MasterResumeJson;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +9,6 @@ import org.hibernate.type.SqlTypes;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Map;
 import java.util.UUID;
 
 @Entity


### PR DESCRIPTION
## Summary
Implements an API to update an existing master resume for the
authenticated user while preserving ownership and data integrity.

This completes the update operation for the Master Resume domain.

## Issue
Closes: #42 Add API to update master resume

## What’s Included
- PUT API to update master resume
- Ownership enforcement (user-scoped updates only)
- Unified request DTO for create/update flows
- JSON structure validation before persistence
- Transactional update with rollback safety
- Metadata update (`updatedAt`) on successful modification

## Endpoint
PUT `/api/master-resume/update`


## Acceptance Criteria
- Only the owner can update the master resume ✅
- Resume JSON structure is validated ✅
- Metadata is updated on change ✅

## Notes
- Update is allowed only if a master resume already exists
- No new master resume is created implicitly
- Errors are surfaced clearly when update is not permitted

## Follow-ups
- Add view master resume API
- Add delete master resume API
- Consider optimistic locking/versioning if concurrent edits are expected