### PR TITLE
Add view and delete master resume APIs

### DIFF
--- a/apps/backend/src/main/java/com/resumeagent/controller/MasterResumeController.java
+++ b/apps/backend/src/main/java/com/resumeagent/controller/MasterResumeController.java
@@ -2,10 +2,12 @@ package com.resumeagent.controller;
 
 import com.resumeagent.dto.request.CreateAndUpdateMasterResume;
 import com.resumeagent.dto.response.CommonResponse;
+import com.resumeagent.dto.response.MasterResumeResponse;
 import com.resumeagent.service.MasterResumeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,12 +33,26 @@ public class MasterResumeController {
     }
 
     @PutMapping(value = "/update")
-    @ResponseStatus(HttpStatus.ACCEPTED)
+    @ResponseStatus(HttpStatus.OK)
     public CommonResponse updateMasterResume(
             Authentication authentication,
             @Valid @RequestBody CreateAndUpdateMasterResume request
     ) {
         String email = authentication.getName();
         return masterResumeService.updateMasterResume(request, email);
+    }
+
+    @GetMapping(value = "/view")
+    @ResponseStatus(HttpStatus.OK)
+    public MasterResumeResponse getMasterResume(Authentication authentication ) {
+        String email = authentication.getName();
+        return masterResumeService.getMasterResume(email);
+    }
+
+    @DeleteMapping(value = "/delete")
+    @ResponseStatus(HttpStatus.OK)
+    public CommonResponse deleteMasterResume(Authentication authentication) {
+        String email = authentication.getName();
+        return masterResumeService.deleteMasterResume(email);
     }
 }

--- a/apps/backend/src/main/java/com/resumeagent/dto/response/MasterResumeResponse.java
+++ b/apps/backend/src/main/java/com/resumeagent/dto/response/MasterResumeResponse.java
@@ -1,0 +1,16 @@
+package com.resumeagent.dto.response;
+
+import com.resumeagent.entity.model.MasterResumeJson;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MasterResumeResponse {
+
+    private MasterResumeJson resumeJson;
+}


### PR DESCRIPTION
## Summary
Implements secure APIs to view and delete the authenticated
user’s master resume.

This completes the read and delete operations for the
Master Resume domain.

## Issues
- Closes: #44 Add API to delete master resume
- Closes: #43 Add API to view master resume

## Endpoints
```http
GET    /api/master-resume/view
DELETE /api/master-resume/delete
```